### PR TITLE
fix: signup validation bugs - password length, bind errors, duplicate email (#19)

### DIFF
--- a/services/UserService.go
+++ b/services/UserService.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/adamkali/mindscape/db/repository"
 	"github.com/adamkali/mindscape/models/requests"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -82,7 +84,7 @@ func (UserService *UserService) addNewUser(
 	repo := repository.New(tx)
 	user, err = repo.CreateUser(UserService.ctx, params)
 	if err != nil {
-		return nil, err
+		return nil, wrapUniqueViolation(err)
 	}
 	tx.Commit(UserService.ctx)
 	fmt.Println(user)
@@ -101,10 +103,25 @@ func (UserService *UserService) addNewUserAdmin(
 	repo := repository.New(tx)
 	user, err = repo.CreateUserAdmin(UserService.ctx, params)
 	if err != nil {
-		return nil, err
+		return nil, wrapUniqueViolation(err)
 	}
 	tx.Commit(UserService.ctx)
 	return &user, nil
+}
+
+func wrapUniqueViolation(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		constraint := pgErr.ConstraintName
+		if strings.Contains(constraint, "email") {
+			return errors.New("A user with this email already exists")
+		}
+		if strings.Contains(constraint, "username") {
+			return errors.New("A user with this username already exists")
+		}
+		return errors.New("A user with these details already exists")
+	}
+	return err
 }
 
 // Login a user

--- a/services/ValidatorService.go
+++ b/services/ValidatorService.go
@@ -43,23 +43,17 @@ func validateUsername(username string) bool {
 }
 
 func validatePassword(s string) (sevenOrMore, number, upper, special bool) {
-	letters := 0
 	for _, c := range s {
 		switch {
 		case unicode.IsNumber(c):
 			number = true
 		case unicode.IsUpper(c):
 			upper = true
-			letters++
 		case unicode.IsPunct(c) || unicode.IsSymbol(c):
 			special = true
-		case unicode.IsLetter(c) || c == ' ':
-			letters++
-		default:
-			//return false, false, false, false
 		}
 	}
-	sevenOrMore = letters > 7
+	sevenOrMore = len(s) >= 8
 	return
 }
 
@@ -70,7 +64,7 @@ func validatePassword(s string) (sevenOrMore, number, upper, special bool) {
 func (ValidatorService ValidatorService) ValidateNewUserRequest(e echo.Context) (*requests.NewUserRequest, error) {
 	validRequest := new(requests.NewUserRequest)
 	if err := e.Bind(&validRequest); err != nil {
-		return nil, err
+		return nil, errors.New("Invalid request body. Please check your input and try again")
 	}
 
 	if !validateUsername(validRequest.Username) {

--- a/services/ValidatorService_test.go
+++ b/services/ValidatorService_test.go
@@ -93,6 +93,11 @@ func WithBadPassword_NoSpecial(request map[string]any) map[string]any {
 	return request
 }
 
+func WithShortMixedPassword(request map[string]any) map[string]any {
+	request["password"] = "Cheese360!"
+	return request
+}
+
 func UserRequestJson() map[string]any {
 	return map[string]any{
 		"username": "adamkali",
@@ -195,6 +200,13 @@ func Run_ValidateNewUserRequest_BadPassword_NoSpecial(v services.ValidatorServic
 		http.MethodPost,
 		CreateUser,
 		WithBadPassword_NoSpecial(UserRequestJson()))))
+}
+
+func Run_ValidateNewUserRequest_ShortMixedPassword(v services.ValidatorService) (*requests.NewUserRequest, error) {
+	return v.ValidateNewUserRequest(NewEchoContext(Request(
+		http.MethodPost,
+		CreateUser,
+		WithShortMixedPassword(UserRequestJson()))))
 }
 
 // </runners>
@@ -307,6 +319,13 @@ func ValidateNewUserRequest_BadPassword_NoLower(t *testing.T) {
 	assert.Equal(t, r.Password, "PASSWORDABC123!")
 }
 
+func ValidateNewUserRequest_ShortMixedPassword(t *testing.T) {
+	r, e := Run_ValidateNewUserRequest_ShortMixedPassword(services.ValidatorService{})
+	assert.NoError(t, e)
+	assert.NotNil(t, r)
+	assert.Equal(t, r.Password, "Cheese360!")
+}
+
 // </evaluators>
 // <map/>
 var Map_ValidateNewUserRequest = map[string]func(t *testing.T){
@@ -322,6 +341,7 @@ var Map_ValidateNewUserRequest = map[string]func(t *testing.T){
 	"BadPassword_NoSpecialCharacter":     ValidateNewUserRequest_BadPassword_NoSpecialCharacter,
 	"BadPassword_NoNumber":               ValidateNewUserRequest_BadPassword_NoNumber,
 	"BadPassword_NoLower":                ValidateNewUserRequest_BadPassword_NoLower,
+	"ShortMixedPassword":                 ValidateNewUserRequest_ShortMixedPassword,
 }
 
 // </tests>


### PR DESCRIPTION
## Summary
- **Password length**: `validatePassword()` now uses `len(s) >= 8` instead of only counting alpha characters — passwords like `Cheese360!` (10 chars) were incorrectly rejected because only 6 letter chars were counted
- **Bind error**: `ValidateNewUserRequest` wraps JSON bind errors with a user-friendly message instead of leaking raw Go decoder errors (e.g., `invalid character '!' in string escape code`)
- **Duplicate email/username**: `UserService` catches Postgres unique constraint violations (SQLSTATE 23505) and returns `"A user with this email already exists"` or `"A user with this username already exists"` instead of raw DB errors

Closes #19

## Test plan
- [x] All 13 `Test_ValidateNewUserRequest` subtests pass (including new `ShortMixedPassword`)
- [x] Full service test suite passes (100+ tests)
- [x] E2E: signed up with password `Cheese360!`, logged in successfully, deleted user

🤖 Generated with [Claude Code](https://claude.com/claude-code)