### PR TITLE
fix: auto-refresh folder tree after creating folder/bookmark

### DIFF
--- a/web/src/components/CreateFolderComponent.tsx
+++ b/web/src/components/CreateFolderComponent.tsx
@@ -39,6 +39,8 @@ export default function CreateFolderComponent(
 		if (response.success) {
 			setFolderName('');
 			setFolderDescription('');
+			refresh?.();
+			setShowCreateFolder(false);
 		} else {
 			console.error('Failed to create folder:', response.message);
 			return;

--- a/web/src/components/FolderComponent.tsx
+++ b/web/src/components/FolderComponent.tsx
@@ -19,6 +19,7 @@ interface FolderComponentProps extends ComponentProps<'div'> {
 	deleteFolder: (id: string) => void;
 	deleteBookmark?: (bookmarkId: string) => void;
 	showCreateFolder: (folderBookmarkRefresh?: () => void) => void;
+	onFolderSelected?: (refreshFn: () => Promise<void>) => void;
 	indent: number;
 }
 
@@ -79,8 +80,26 @@ export default function FolderComponent(props: FolderComponentProps) {
 		}
 	};
 
+	const refreshFolder = async () => {
+		const response = await api.folders.getFolders({
+			folderId: folder.id || '',
+			authorization: `Bearer ${auth.token()}`,
+		});
+		if (response.success && response.data) {
+			setChildren(response.data.children || []);
+			setBookmarks(response.data.bookmarks || []);
+		} else {
+			console.error(
+				'Failed to refresh folder:',
+				response.message,
+				response.data,
+				response.success,
+			);
+		}
+	};
+
 	const refreshBookmarks = async () => {
-		const response = await api.bookmarks.align({
+		const response = await api.bookmarks.getBookmarks({
 			parentId: folder.id || '',
 			authorization: `Bearer ${auth.token()}`,
 		});
@@ -116,6 +135,7 @@ export default function FolderComponent(props: FolderComponentProps) {
 								deleteBookmark={props.deleteBookmark}
 								indent={indentNext()}
 								showCreateFolder={props.showCreateFolder}
+								onFolderSelected={props.onFolderSelected}
 							/>
 						)}
 					</For>
@@ -208,12 +228,13 @@ export default function FolderComponent(props: FolderComponentProps) {
 					onSelect={(folderId) => {
 						setSelectedFolder(folderId);
 						openFolder();
+						props.onFolderSelected?.(refreshFolder);
 					}}
 					onDelete={deleteFolder}
 					onCreateBookmark={(folderId) => {
 						setSelectedFolder(folderId);
 						props.showCreateFolder(async () => {
-							await refreshBookmarks();
+							await refreshFolder();
 						});
 					}}
 					onDrop={handleDrop}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -143,6 +143,17 @@ const Home = () => {
 		bookmarkRefresh = () => {};
 	};
 
+	// set overwritable callback for create folder component (parent folder refresh)
+	let folderRefresh: () => void = () => {};
+	const openCreateFolderComponent = () => {
+		setShowCreateFolder(true);
+		setShowCreateBookmark(false);
+	};
+
+	const handleFolderSelected = (refreshFn: () => Promise<void>) => {
+		folderRefresh = refreshFn;
+	};
+
 	const handleRootDragOver = (e: DragEvent) => {
 		// Only handle if the target is the root container or empty space, not folder cards
 		const target = e.target as HTMLElement;
@@ -247,7 +258,7 @@ const Home = () => {
 							<Button
 								variant="primary"
 								onClick={() => {
-									setShowCreateFolder(true);
+									openCreateFolderComponent();
 								}}
 							>
 								<AddFolder />
@@ -261,7 +272,11 @@ const Home = () => {
 								auth={auth}
 								setShowCreateFolder={setShowCreateFolder}
 								folderAPIRef={foldersApi}
-								refresh={fetchRootFolders}
+								refresh={async () => {
+								await fetchRootFolders();
+								folderRefresh();
+								folderRefresh = () => {};
+							}}
 							/>
 						</Show>
 
@@ -300,6 +315,7 @@ const Home = () => {
 											deleteFolder={deleteFolder}
 											deleteBookmark={deleteBookmark}
 											showCreateFolder={openCreateBookmarkComponent}
+											onFolderSelected={handleFolderSelected}
 											indent={0}
 										/>
 									))}


### PR DESCRIPTION
## Summary
- **CreateFolderComponent**: Call `refresh()` and close modal after successful folder creation so the tree updates immediately
- **FolderComponent**: Fix `refreshBookmarks` to use `getBookmarks()` instead of non-existent `align()`, add `refreshFolder` function, and wire `onFolderSelected` callback so parent folders refresh when subfolders/bookmarks are created inside them
- **Home.tsx**: Add `folderRefresh` callback pattern (mirrors existing `bookmarkRefresh`) so the selected parent folder re-fetches its children after subfolder creation

Closes #12

## Test plan
- [x] Create a root folder → appears immediately in tree without page refresh
- [x] Open a folder, create a subfolder inside it → appears in parent's children immediately
- [ ] Open a folder, create a bookmark inside it → appears in folder immediately
- [ ] Drag-drop a bookmark into a folder → folder contents update correctly
- [ ] Drag-drop a folder into another folder → target folder updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)